### PR TITLE
fix: stop animation after player stops 'carrying' wheelchair

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -145,6 +145,8 @@ PickUp = function(wheelchairObject)
 			DetachEntity(wheelchairObject, true, true)
 		end
 	end
+
+	StopAnimTask(PlayerPedId(), 'anim@heists@box_carry@', 'idle', 1)
 end
 
 DrawText3Ds = function(coords, text, scale)

--- a/client/main.lua
+++ b/client/main.lua
@@ -146,7 +146,7 @@ PickUp = function(wheelchairObject)
 		end
 	end
 
-	StopAnimTask(PlayerPedId(), 'anim@heists@box_carry@', 'idle', 1)
+	StopAnimTask(PlayerPedId(), 'anim@heists@box_carry@', 'idle', 1.0)
 end
 
 DrawText3Ds = function(coords, text, scale)


### PR DESCRIPTION
Releasing the wheelchair doesn't stop the box carry animation, and sometimes prevents the player from picking up another wheelchair - even if they are the only player on the server.

The placement of this line may not be the best given the existing structure, but is relatively consistent to minimise the additional code footprint after the wheelchair has been detached from the player.